### PR TITLE
Remove oasis dependencies

### DIFF
--- a/packages/gnt.0.5.0/opam
+++ b/packages/gnt.0.5.0/opam
@@ -7,4 +7,4 @@ build: [
 remove: [
   [make "PREFIX=%{prefix}%" "uninstall"]
 ]
-depends: ["oasis" "ounit" "cstruct" {>= "1.0.1"}]
+depends: ["ounit" "cstruct" {>= "1.0.1"}]

--- a/packages/rrd-transport.0.6.0/opam
+++ b/packages/rrd-transport.0.6.0/opam
@@ -7,4 +7,4 @@ build: [
 remove: [
   [make "PREFIX=%{prefix}%" "uninstall"]
 ]
-depends: ["oasis" "cmdliner" "cstruct" {>= "1.0.1"} "crc" "xcp" "xcp-rrd" "gnt"]
+depends: ["cmdliner" "cstruct" {>= "1.0.1"} "crc" "xcp" "xcp-rrd" "gnt"]


### PR DESCRIPTION
Oasis isn't actually needed for the build, since the autogen files are
already created.
