### PR TITLE
forkexec: depends on xcp

### DIFF
--- a/packages/forkexecd.0.9.2/opam
+++ b/packages/forkexecd.0.9.2/opam
@@ -15,4 +15,5 @@ depends: [
   "uuidm"
   "stdext"
   "re"
+  "xcp"
 ]


### PR DESCRIPTION
Signed-off-by: David Scott dave.scott@citrix.com
