### PR TITLE
Release xenctrl.0.9.21, enabling libxl by default

### DIFF
--- a/packages/xenctrl/xenctrl.0.9.21/descr
+++ b/packages/xenctrl/xenctrl.0.9.21/descr
@@ -1,0 +1,2 @@
+Low-level hypercall bindings. These are based on the code in xen-unstable.hg,
+with minor patches for out-of-tree building.

--- a/packages/xenctrl/xenctrl.0.9.21/opam
+++ b/packages/xenctrl/xenctrl.0.9.21/opam
@@ -1,0 +1,21 @@
+opam-version: "1"
+maintainer: "dave.scott@eu.citrix.com"
+build: [
+  [make "configure"]
+  ["./configure"]
+  [make]
+  [make "install" "BINDIR=%{bin}%"]
+]
+remove: [
+  [make "uninstall"]
+]
+depends: [
+  "ocamlfind"
+  "lwt"
+  "cmdliner"
+]
+depexts: [
+  [["debian"] ["libxen-dev"]]
+  [["ubuntu"] ["libxen-dev"]]
+]
+

--- a/packages/xenctrl/xenctrl.0.9.21/url
+++ b/packages/xenctrl/xenctrl.0.9.21/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/xapi-project/ocaml-xen-lowlevel-libs/archive/0.9.21.tar.gz"
+checksum: "9f33369fe5b18d442abf340367f4e343"


### PR DESCRIPTION
Signed-off-by: David Scott dave.scott@citrix.com
