### PR TITLE
xapi-idl now needs cohttp.0.15.2

### DIFF
--- a/packages/xapi-idl/xapi-idl.0.10.0/opam
+++ b/packages/xapi-idl/xapi-idl.0.10.0/opam
@@ -10,7 +10,7 @@ remove: [
 depends: [ "uri"
            "re"
            "cmdliner"
-           "cohttp" {= "0.11.2"}
+           "cohttp" {= "0.15.2"}
            "xmlm"
            "rpc" {> "1.4.0"}
            "ocamlfind"


### PR DESCRIPTION
Signed-off-by: David Scott <dave.scott@citrix.com>