### PR TITLE
Remove ocveralls from message-switch's OPAM file

### DIFF
--- a/packages/message-switch/message-switch.0.11.0/opam
+++ b/packages/message-switch/message-switch.0.11.0/opam
@@ -26,6 +26,5 @@ depends: [
   "ssl"
   "oasis"
   "async"
-  "ocveralls" {test}
   "bisect"
 ]


### PR DESCRIPTION
It's not needed for the build, and is explicitly installed by the
coverage script.