### PR TITLE
Pin xapi-backtrace to sexplib.113.00.00

### DIFF
--- a/packages/xapi-backtrace/xapi-backtrace.0.3/opam
+++ b/packages/xapi-backtrace/xapi-backtrace.0.3/opam
@@ -10,6 +10,6 @@ remove: [
 ]
 depends: [
   "ocamlfind"
-  "sexplib"
+  "sexplib" {<= "113.00.00"}
   "rpc"
 ] 


### PR DESCRIPTION
xapi-backtrace needs sexplib.syntax, which has been removed from more recent versions of sexplib.