### PR TITLE
Pin shared-block-ring to sexplib.113.00.00

### DIFF
--- a/packages/shared-block-ring/shared-block-ring.2.0.0/opam
+++ b/packages/shared-block-ring/shared-block-ring.2.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "mirage-types"
   "mirage-block-unix"
   "mirage-clock-unix"
-  "sexplib"
+  "sexplib" {<= "113.00.00"}
   "io-page"
   "io-page-unix"
   "cmdliner"

--- a/packages/shared-block-ring/shared-block-ring.mirage#master/opam
+++ b/packages/shared-block-ring/shared-block-ring.mirage#master/opam
@@ -18,7 +18,7 @@ depends: [
   "mirage-types-lwt"
   "mirage-block-unix"
   "mirage-clock-unix"
-  "sexplib"
+  "sexplib" {<= "113.00.00"}
   "io-page"
   "io-page-unix"
   "cmdliner"


### PR DESCRIPTION
shared-block-ring needs sexplib.syntax, which has been removed from more
recent versions of sexplib.