### PR TITLE
Fix systemd and new package versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ To build the xapi-project toolstack components from source:
 
 First install common development tools and headers:
 ```
-apt-get install build-essential libxen-dev libvirt-dev autoconf m4
+apt-get install build-essential libxen-dev libvirt-dev autoconf m4  blktap-dev libsystemd-dev
 ```
 
 Second install the [opam](http://opam.ocaml.org/) source package manager.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ First install common development tools and headers:
 apt-get install build-essential libxen-dev libvirt-dev autoconf m4  blktap-dev libsystemd-dev
 ```
 
+For some of the dependencies you may also need to install the following:
+```
+apt-get install libssl-ocaml-dev libffi-dev libpci-dev
+```
+
 Second install the [opam](http://opam.ocaml.org/) source package manager.
 
 Initialise an opam configuration and add this repo: (note this will install the OCaml compiler from source,

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ apt-get install build-essential libxen-dev libvirt-dev autoconf m4  blktap-dev l
 
 For some of the dependencies you may also need to install the following:
 ```
-apt-get install libssl-ocaml-dev libffi-dev libpci-dev
+apt-get install libssl-ocaml-dev
 ```
 
 Second install the [opam](http://opam.ocaml.org/) source package manager.
@@ -24,6 +24,7 @@ opam remote add xapi-project git://github.com/xapi-project/opam-repo-dev
 
 To build xapi:
 ```
+opam depext xapi.xapi-project#master
 opam install xapi
 ```
 

--- a/packages/libvirt/libvirt.djs55#typo/opam
+++ b/packages/libvirt/libvirt.djs55#typo/opam
@@ -15,7 +15,7 @@ depends: [
 ]
 depexts: [
   [["debian"] ["libvirt-dev" "autoconf"]]
-  [["ubuntu"] ["libvirt-dev" "autoconf"]]
+  [["ubuntu"] ["libvirt-dev" "autoconf" "blktap-dev"]]
   [["centos"] ["libvirt-devel" "autoconf"]]
 ]
 

--- a/packages/systemd/systemd.xapi-project#master/descr
+++ b/packages/systemd/systemd.xapi-project#master/descr
@@ -1,0 +1,3 @@
+OCaml module for native access to the systemd facilities
+
+OCaml library allowing interaction with systemd and journald

--- a/packages/systemd/systemd.xapi-project#master/opam
+++ b/packages/systemd/systemd.xapi-project#master/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+name: "systemd"
+version: "1.1"
+maintainer: "Juergen Hoetzel <juergen@archlinux.org>"
+authors: "Juergen Hoetzel <juergen@archlinux.org>"
+homepage: "https://github.com/juergenhoetzel/ocaml-systemd/"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "https://github.com/juergenhoetzel/ocaml-systemd.git"
+license: "LGPL-3 with OCaml linking exception"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "systemd"]
+depends: "ocamlfind"
+depexts: [
+  [["debian"] ["libsystemd-dev"]]
+  [["ubuntu"] ["libsystemd-dev"]]
+  [["centos"] ["systemd-devel"]]
+]

--- a/packages/systemd/systemd.xapi-project#master/url
+++ b/packages/systemd/systemd.xapi-project#master/url
@@ -1,0 +1,1 @@
+git: "git://github.com/juergenhoetzel/ocaml-systemd"

--- a/packages/xapi-forkexecd/xapi-forkexecd.xapi-project#master/opam
+++ b/packages/xapi-forkexecd/xapi-forkexecd.xapi-project#master/opam
@@ -15,12 +15,12 @@ remove: [make "uninstall" "BINDIR=%{bin}%" "SBINDIR=%{bin}%" "ETCDIR=%{prefix}%/
 depends: [
   "ocamlfind" {build}
   "oasis" {build}
-  "systemd" {build}
+  "systemd" {= "xapi-project#master"}
   "syslog"
   "rpc"
   "fd-send-recv"
   "uuidm"
   "xapi-stdext" {>= "2.0.0"}
   "re"
-  "xapi-idl"
+  "xapi-idl" {= "xapi-project#master"}
 ]

--- a/packages/xapi-forkexecd/xapi-forkexecd.xapi-project#master/opam
+++ b/packages/xapi-forkexecd/xapi-forkexecd.xapi-project#master/opam
@@ -1,20 +1,26 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "dave.scott@eu.citrix.com"
+authors: "xen-api@lists.xen.org"
+homepage: "https://github.com/xapi-project/"
+bug-reports: "https://github.com/xapi-project/forkexecd/issues"
+dev-repo: "git://github.com/xapi-project/forkexecd"
 build: [
+  ["oasis" "setup"]
   [make]
+]
+install: [
   [make "install" "BINDIR=%{bin}%" "SBINDIR=%{bin}%" "ETCDIR=%{prefix}%/etc"]
 ]
-remove: [
-  [make "uninstall" "BINDIR=%{bin}%" "SBINDIR=%{bin}%" "ETCDIR=%{prefix}%/etc"]
-  ["ocamlfind" "remove" "forkexec"]
-]
+remove: [make "uninstall" "BINDIR=%{bin}%" "SBINDIR=%{bin}%" "ETCDIR=%{prefix}%/etc"]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
+  "oasis" {build}
+  "systemd" {build}
   "syslog"
   "rpc"
   "fd-send-recv"
   "uuidm"
-  "xapi-stdext" {= "xapi-project#master"}
+  "xapi-stdext" {>= "2.0.0"}
   "re"
-  "xapi-idl" {= "xapi-project#master"}
+  "xapi-idl"
 ]


### PR DESCRIPTION
This allows to `opam install xapi` (almost) and have a working merlin environment. Tested on ubuntu 16.06