### PR TITLE
README.md: fix "opam pin add" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ git clone git://github.com/xapi-project/stdext
 Next tell opam to use the custom version:
 ```
 opam remove stdext
-opam pin stdext stdext
+opam pin add stdext stdext
 ```
 Next install the component you want to test:
 ```


### PR DESCRIPTION
"opam pin" first requires a command argument, without one it (Opam
1.2.2) defaults to the "list" command. Add the missing "add" command
that we need in this case - without this the command in the README
doesn't work.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>