### PR TITLE
Add xapi-test-utils OPAM dependency

### DIFF
--- a/packages/xapi/xapi.xapi-project#master/opam
+++ b/packages/xapi/xapi.xapi-project#master/opam
@@ -9,6 +9,7 @@ build-test: [make "test" ]
 remove: ["rm" "%{bin}%/xapi"]
 depends: [
   "ocamlfind"
+  "xapi-test-utils" {= "xapi-project#master"}
   "xapi-idl" {= "xapi-project#master"}
   "xapi-libs-transitional" {= "xapi-project#master"}
   "xen-api-client" {= "xapi-project#master"}


### PR DESCRIPTION
Add the missing xapi-test-utils OPAM dependency to the opam file. It is
declared as a "BuildRequires" in the spec file of xapi, but it was
missing from the opam file.

The corresponding PR for the opam file in the xen-api repo is https://github.com/xapi-project/xen-api/pull/2881

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>