### PR TITLE
Make xen-api-client depend on cstruct-lwt

### DIFF
--- a/packages/xen-api-client/xen-api-client.xapi-project#master/opam
+++ b/packages/xen-api-client/xen-api-client.xapi-project#master/opam
@@ -14,6 +14,7 @@ depends: [
   "oasis" {build}
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.0.1"}
+  "cstruct-lwt"
   "ssl"
   "ounit" {test}
   "cohttp" {>= "0.12.0"}


### PR DESCRIPTION
This is needed because xen-api-client's _oasis file uses cstruct.lwt in a
BuildDepends clause.

Signed-off-by: Jonathan Davies <jonathan.davies@citrix.com>